### PR TITLE
Fix xss injection from entry_name

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,7 +148,9 @@ function createRow(entry, tr, games, teams) {
 
   // Bit of entry name cleaning up as the software default's to
   // format of "User name's bracket 1" and that's ugly
-  nameTd.innerHTML = entry_name.replace(/'s bracket \d+/, "");
+  const entryNameCleaned = entry_name.replace(/'s bracket \d+/, "")
+  const nameTdText = document.createTextNode(entryNameCleaned);
+  nameTd.appendChild(nameTdText);
   nameTd.classList.add("wide");
   nameTd.dataset.heading = "name";
 


### PR DESCRIPTION
If you manage input something html-like,  for example `<b style="font-size:666px">FOO</b>`, as your bracket name in the original bracket challenge site it will currently be applied as HTML.