### PR TITLE
Temporary fix for getting bad data

### DIFF
--- a/app.js
+++ b/app.js
@@ -319,6 +319,7 @@ function createRoundSelector(label, name, fieldset) {
 async function fetchData() {
   if (ENTRIES_DATA === null) {
     ENTRIES_DATA = (await fetch(ENTRIES_URL).then((res) => res.json())).entries;
+    ENTRIES_DATA = uniqueBy(ENTRIES_DATA, "entry_id");
   }
 
   if (SERIES_DATA === null) {
@@ -377,3 +378,15 @@ async function renderTable(toDisplay) {
 }
 
 renderFields().then(() => renderTable());
+
+function uniqueBy(array, key) {
+  let uniques = [];
+  for (let idx in array) {
+    let obj = array[idx];
+    console.log({ obj, uniques });
+    if (uniques.find((ex) => ex[key] == obj[key]) == undefined) {
+      uniques.push(obj);
+    }
+  }
+  return uniques;
+}


### PR DESCRIPTION
At the time of the fix, the API sends garbage data. There's near-duplicate data for some (but not all) entries with just extra ranks added randomly.

To combat this for now, I filter the initial list to unique entries by entry id and throw out everything else.

This has the possibility to be wrong if more trash data comes in later but for now, it seems to work. I'll fix it again when the next update happens, if it breaks.